### PR TITLE
feat: log the SHA256 hash of the installer

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -9,7 +9,7 @@ jobs:
   build2019:
     strategy:
       matrix:
-        stunnel_version: [5.66]
+        stunnel_version: [5.67]
         windows_version: [1809]
     runs-on: windows-2019
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir "C:\Users\ContainerAdministrator\stunnel"
 WORKDIR C:\\Users\\ContainerAdministrator\\stunnel
 
 RUN curl -fSLo stunnel_installer.exe https://www.stunnel.org/downloads/stunnel-%STUNNEL_VERSION%-win64-installer.exe \
+ && powershell -Command "Write-Output `nSHA256` Hash:`n; (Get-FileHash stunnel_installer.exe -Algorithm SHA256).Hash; Write-Output `n" \
  && stunnel_installer.exe /S \
  && del stunnel_installer.exe
 


### PR DESCRIPTION
This allows a verification that the hash is correct (but not automatically).