### PR TITLE
feat: Stunnel 5.71

### DIFF
--- a/.github/workflows/build_alpine_images.yml
+++ b/.github/workflows/build_alpine_images.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - stunnel_version: 5.70-r0
+          - stunnel_version: 5.71-r0
             alpine_version: 3.18.3
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build_windows_images.yml
+++ b/.github/workflows/build_windows_images.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - stunnel_version: '5.70'
-            stunnel_sha256: c50fb79329ddbf095e65ba8817a0249188aa5b25f15557f8504d8f65876034d9
+          - stunnel_version: '5.71'
+            stunnel_sha256: 945df5118473bcbf1ecdc5561fd6f26743c5dd1fd82e1a25199d0fd5c39a9373
             windows_version: 1809
     runs-on: windows-2019
     permissions:


### PR DESCRIPTION
* Security bugfixes
   - OpenSSL DLLs updated to version 3.1.3.
* Bugfixes
   - Fixed the console output of tstunnel.exe.
* Features sponsored by SAE IT-systems
   - OCSP stapling is requested and verified in the client mode.
   - Using "verifyChain" automatically enables OCSP stapling in the client mode.
   - OCSP stapling is always available in the server mode.
   - An inconclusive OCSP verification breaks TLS negotiation. This can be disabled with "OCSPrequire = no".
   - Added the "TIMEOUTocsp" option to control the maximum time allowed for connecting an OCSP responder.
* Features
   - Added support for Red Hat OpenSSL 3.x patches.