### PR TITLE
chore: Stunnel 5.73

### DIFF
--- a/.github/workflows/build_alpine_images.yml
+++ b/.github/workflows/build_alpine_images.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - stunnel_version: 5.72-r0
-            alpine_version: 3.19.1
+          - stunnel_version: 5.73-r0
+            alpine_version: 3.21.0
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build_windows_images.yml
+++ b/.github/workflows/build_windows_images.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - stunnel_version: '5.72'
-            stunnel_sha256: 1037c53f8ab590c2f3001e54cf381c3ea4225e9670b03870191383060e6851e7
+          - stunnel_version: '5.73'
+            stunnel_sha256: d686b1a4135947718e7a8157a8cb6694ed50e2267713de1972941148a8859789
             windows_version: 1809
     runs-on: windows-2019
     permissions:


### PR DESCRIPTION
* Security bugfixes
  - OpenSSL DLLs updated to version 3.3.2.
  - OpenSSL FIPS Provider updated to version 3.0.9.
* Bugfixes
  - Fixed a memory leak while reloading stunnel.conf sections with "client=yes" and "delay=no".
  - Fixed TIMEOUTocsp with values greater than 4.
  - Fix the IPv6 test on a non-IPv6 machine.
* Features
  - HELO replaced with EHLO in the post-STARTTLS SMTP protocol negotiation (thx to Peter Pentchev).
  - OCSP stapling fetches moved away from server threads.
  - Improved client-side session resumption.
  - Added support for the mimalloc allocator.
  - Check for protocolHost moved to configuration file processing for the client-side CONNECT protocol.
  - Clarified some confusing OpenSSL's certificate verification error messages.
  - stunnel.nsi updated for Debian 13 and Fedora.
  - Improved NetBSD compatibility.