### PR TITLE
deps: pin trivy-action version

### DIFF
--- a/.github/workflows/build_alpine_images.yml
+++ b/.github/workflows/build_alpine_images.yml
@@ -40,7 +40,7 @@ jobs:
           ALPINE_VERSION: ${{ matrix.alpine_version }}
         run: bash build_container.sh
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/stunnel:${{ matrix.stunnel_version }}-alpine-${{ matrix.alpine_version }}
           format: 'table'


### PR DESCRIPTION
Asana Task: [Trivy after-action followups](https://app.asana.com/1/15492006741476/project/1113179098808463/task/1213749140444703)

Caches have been cleared.
This pins `trivy-action` to the recommended version from https://redirect.github.com/aquasecurity/trivy/discussions/10425

CI will fail because I haven't fully turned actions back on.
My plan is to force merge this PR without CI passing (but after approval), then turn actions all the way back on. If it causes CI to fail on main, that's not that bad, I'll make a followup PR to fix it.

It should be fine to run `@master` now, assuming they've deleted all malicious code from their repo, but I'll do an extra song and dance here to stay a little further removed from it.