### PR TITLE
deps: update alpine and stunnel

### DIFF
--- a/.github/workflows/build_alpine_images.yml
+++ b/.github/workflows/build_alpine_images.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - stunnel_version: 5.73-r0
-            alpine_version: 3.21.0
+          - stunnel_version: 5.76-r0
+            alpine_version: 3.23.4
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Asana Task: [Trivy after-action followups](https://app.asana.com/1/15492006741476/project/1113179098808463/task/1213749140444703)

After reenabling GitHub actions and Trivy, the latest CI run failed due to Trivy detecting security vulnerabilities. https://github.com/mbta/stunnel-docker/actions/runs/24650694544/job/72072650533

I suspect this is due to an outdated version of Alpine. So this PR updates Alpine. And while I'm at it, stunnel, too.

[alpine versions](https://hub.docker.com/_/alpine). 3.23.4 is the latest.

[stunnel changelog](https://www.stunnel.org/NEWS.html). The changelog goes up to 5.78, but [Alpine only has up to stunnel 5.76](https://pkgs.alpinelinux.org/package/edge/community/x86/stunnel). There's some fixes labeled "Urgency: HIGH" or "security bugfixes". I haven't personally gone through the list though.

I checked that the docker file builds locally, but I haven't checked that trivy works. We'll see that whenever CI runs. CI doesn't run on the branch automatically. I could run it manually, but that would also push the new built version to the repo, so I'll do that after approval (but before merge, just in case it doesn't succeed).

I don't know what uses the image that this repo generates, but whatever does, we'll have to update it from `ghcr.io/mbta/stunnel:5.73-r0-alpine-3.21.0` to ghcr.io/mbta/stunnel:5.76-r0-alpine-3.23.4`