### PR TITLE
deps: update GHA deps to move from nodejs 20 to 24

### DIFF
--- a/.github/workflows/build_alpine_images.yml
+++ b/.github/workflows/build_alpine_images.yml
@@ -25,9 +25,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || github.run_attempt != '1'
         run: echo "FORCE=1" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
           ALPINE_VERSION: ${{ matrix.alpine_version }}
         run: bash build_container.sh
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/stunnel:${{ matrix.stunnel_version }}-alpine-${{ matrix.alpine_version }}
           format: 'table'


### PR DESCRIPTION
Asana Task: None

In #12 , I noticed a CI warning that some our github actions were still using nodejs20.

This bumps them to nodejs24.

~~I pinned the docker action, but left the first-party `checkout` action unpinned, cuz we haven't decided on a strategy for that yet.~~ Edit: I pinned all dependencies.

Doesn't update the windows versions, cuz they're deleted in #13 

Checklist:
- [x] Manually run CI and verify that it works and there's no nodejs20 error.

There won't be any change to the created container or its version name.