### PR TITLE
Fix: Bump alpine_version

### DIFF
--- a/.github/workflows/build_alpine_images.yml
+++ b/.github/workflows/build_alpine_images.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - stunnel_version: 5.76-r0
-            alpine_version: 3.23.4
+            alpine_version: 3.24.1
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_IMAGE=alpine:3
 
-FROM $BUILD_IMAGE as build
+FROM $BUILD_IMAGE AS build
 ARG STUNNEL_VERSION
 
 RUN apk add --no-cache "stunnel=${STUNNEL_VERSION}" && \


### PR DESCRIPTION
see: [stunnel-docker trivy vulnerability found](https://app.asana.com/1/15492006741476/task/1215718475586076)

Currently trivvy is failing our [gh actions](https://github.com/mbta/stunnel-docker/actions/runs/27528955337/) due to a vulnerability:
```
Library: libcrypto3
Vulnerability: CVE-2026-45447
Severity: HIGH
Stauts: fixed
Installed Version: 3.5.6-r0
Fixed Version: 3.5.7-r0
Title: openssl: Heap Use-After-Free in OpenSSL PKCS7_verify() 
https://avd.aquasec.com/nvd/cve-2026-45447
```

Surely enough I got the following output when running in the docker container:
```
% apk info libcrypto3
libcrypto3-3.5.6-r0 description:
Crypto library from openssl
```

Which is deprecated, and bumping the Alpine version to `3.24.1` gives
```
% apk info libcrypto3
libcrypto3-3.5.7-r0 description:
Crypto library from openssl
```

Which should solve this issue, so lets see if trivvy passes in this PR.

stunnel is still outdated in alpine and the maintainers have yet to update it (see [flagged](https://pkgs.alpinelinux.org/flagged?name=stunnel&branch=edge&repo=&arch=x86_64&maintainer=)), but thats not something we can quickly address here